### PR TITLE
[fix] remove legacy markup from category indexes

### DIFF
--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/configuring-gantt.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/configuring-gantt.md
@@ -7,7 +7,6 @@ sidebar_label: "Gantt-Diagramm konfigurieren"
 
 ![gantt_basic](/img/gantt_basic.png)
 
-((index
 - [Configuration](guides/common-configuration.md)
 - [Gantt Layout](guides/layout-config.md)
 - [Resource Management](guides/resource-management.md)
@@ -15,4 +14,3 @@ sidebar_label: "Gantt-Diagramm konfigurieren"
 - [Multiple Charts on a Page](guides/multiple-gantts.md)
 - [Peculiarities of Gantt Instance](guides/gantt-instance.md)
 - [Using Gantt on the server](guides/using-gantt-on-server.md)
-))

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/dependencies.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/dependencies.md
@@ -7,9 +7,7 @@ sidebar_label: "Konfiguration von Abhängigkeitsverbindungen"
 
 ![gantt_arrows](/img/gantt_arrows.png)
 
-((index
 - [Link Properties](guides/link-properties.md)
 - [Getting the Link Object/Id](guides/link-object-operations.md)
 - [Adding/Updating/Deleting Links](guides/crud-dependency.md)
 - [Auto Scheduling](guides/auto-scheduling.md)
-))

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/export-common.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/export-common.md
@@ -5,7 +5,6 @@ sidebar_label: "Exportieren und Importieren von Daten"
 
 # Exportieren und Importieren von Daten
 
-((index
 - [Export to PDF and PNG](guides/export.md)
 - [Export/Import for Excel, Export to iCal](guides/excel.md)
 - [Export and Import from MS Project](guides/export-msproject.md)
@@ -13,4 +12,3 @@ sidebar_label: "Exportieren und Importieren von Daten"
 - [Serializing Data into XML and JSON](guides/serialization.md)
 - [Export and Import Data on Node.js](guides/export-nodejs.md)
 - [Export Modules](guides/export-modules.md)
-))

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/task-bars.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/task-bars.md
@@ -7,7 +7,6 @@ sidebar_label: "Konfiguration von Aufgaben"
 
 ![gantt_tasks](/img/gantt_tasks.png)
 
-((index
 - [Task Types](guides/task-types.md)
 - [Task Properties](guides/task-properties.md)
 - [Task Object/Id](guides/task-object-operations.md)
@@ -28,4 +27,3 @@ sidebar_label: "Konfiguration von Aufgaben"
 - [Dragging Tasks within the Timeline](guides/dnd.md)
 - [Creating/Selecting Tasks with DnD](guides/advanced-dnd.md)
 - [Manually Scheduled Summary Tasks](guides/custom-projects-dates.md)
-))

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/time-scale.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/time-scale.md
@@ -7,7 +7,6 @@ sidebar_label: "Skalierung konfigurieren"
 
 ![gantt_right](/img/gantt_right.png)
 
-((index
 - [Setting up Scale](guides/configuring-time-scale.md) 
 - [Zooming](guides/zooming.md)
 - [Highlighting  Time Slots](guides/highlighting-time-slots.md)
@@ -15,4 +14,3 @@ sidebar_label: "Skalierung konfigurieren"
 - [Hiding Time Units in the Scale](guides/custom-scale.md)
 - [Adding Vertical Markers](guides/markers.md)
 - [RTL (Right-to-left) Mode](guides/rtl-mode.md)
-))

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/work-with-dates.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/work-with-dates.md
@@ -5,7 +5,5 @@ sidebar_label: "Arbeiten mit Datumsangaben"
 
 # Arbeiten mit Datumsangaben
 
-((index
 - [Date Format Specification](guides/date-format.md)
 - [Operations with Dates](guides/date-operations.md)
-))

--- a/i18n/ko/docusaurus-plugin-content-docs/current/guides/configuring-gantt.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/guides/configuring-gantt.md
@@ -7,7 +7,6 @@ sidebar_label: "간트 차트 구성하기"
 
 ![gantt_basic](/img/gantt_basic.png)
 
-((index
 - [Configuration](guides/common-configuration.md)
 - [간트 레이아웃](guides/layout-config.md)
 - [리소스 관리](guides/resource-management.md)
@@ -15,4 +14,3 @@ sidebar_label: "간트 차트 구성하기"
 - [여러 개의 차트를 한 페이지에 표시하기](guides/multiple-gantts.md)
 - [Gantt 인스턴스의 특이점](guides/gantt-instance.md)
 - [서버에서 Gantt 사용하기](guides/using-gantt-on-server.md)
-))

--- a/i18n/ko/docusaurus-plugin-content-docs/current/guides/dependencies.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/guides/dependencies.md
@@ -7,9 +7,7 @@ sidebar_label: "의존성 링크 구성하기"
 
 ![gantt_arrows](/img/gantt_arrows.png)
 
-((index
 - [링크 속성](guides/link-properties.md)
 - [링크 객체/ID 가져오기](guides/link-object-operations.md)
 - [링크 추가/수정/삭제](guides/crud-dependency.md)
 - [자동 스케줄링](guides/auto-scheduling.md)
-))

--- a/i18n/ko/docusaurus-plugin-content-docs/current/guides/edit-form.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/guides/edit-form.md
@@ -7,10 +7,8 @@ sidebar_label: "편집 폼 구성하기"
 
 ![lightbox](/img/lightbox.png)
 
-((index
 - [Lightbox 요소 구성하기](guides/default-edit-form.md)
 - [Lightbox 요소 작업하기](guides/lightbox-manipulations.md)
 - [커스텀 엘리먼트 생성하기](guides/custom-editor.md)
 - [Custom Lightbox](guides/custom-edit-form.md)
 - [라이트박스의 버튼 변경하기](guides/custom-button.md)
-))

--- a/i18n/ko/docusaurus-plugin-content-docs/current/guides/export-common.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/guides/export-common.md
@@ -5,7 +5,6 @@ sidebar_label: "데이터 내보내기 및 가져오기"
 
 # 데이터 내보내기 및 가져오기
 
-((index
 - [Export to PDF and PNG](guides/export.md)
 - [Export/Import for Excel, Export to iCal](guides/excel.md)
 - [MS Project로부터의 내보내기 및 가져오기](guides/export-msproject.md)
@@ -13,4 +12,3 @@ sidebar_label: "데이터 내보내기 및 가져오기"
 - [데이터를 XML 및 JSON으로 직렬화하기](guides/serialization.md)
 - [Node.js에서 데이터 내보내기 및 가져오기](guides/export-nodejs.md)
 - [모듈 내보내기](guides/export-modules.md)
-))

--- a/i18n/ko/docusaurus-plugin-content-docs/current/guides/export-modules.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/guides/export-modules.md
@@ -5,10 +5,8 @@ sidebar_label: "모듈 내보내기"
 
 # 모듈 내보내기
 
-((index
 - [Export Service - 독립형 설치를 위한 시스템 요구 사항](guides/export-requirements.md)
 - [PDF Export Module의 새로운 기능](guides/pdf-export-module-whatsnew.md)
 - [MSP 프로젝트 내보내기 모듈의 새로운 기능](guides/msp-export-module-whatsnew.md)
 - [PDF 내보내기 모듈](guides/pdf-export-module.md)
 - [MS Project용 내보내기 모듈](guides/msp-export-module.md)
-))

--- a/i18n/ko/docusaurus-plugin-content-docs/current/guides/extra-resources.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/guides/extra-resources.md
@@ -5,7 +5,6 @@ sidebar_label: "공통 기능"
 
 # 공통 기능
 
-((index
 - [로컬라이제이션](guides/localization.md)
 - [전체 화면 모드](guides/fullscreen-mode.md)
 - [Empty State Screen](guides/empty-state-screen.md)
@@ -16,4 +15,3 @@ sidebar_label: "공통 기능"
 - [키보드 내비게이션](guides/keyboard-navigation.md)
 - [Content Security Policy 준수](guides/content-security-policy.md)
 - [JQuery와의 통합](guides/jquery-integration.md)
-))

--- a/i18n/ko/docusaurus-plugin-content-docs/current/guides/general-gantt-chart.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/guides/general-gantt-chart.md
@@ -7,8 +7,6 @@ sidebar_label: "페이지에 간트 차트 생성하기"
 
 ![gantt_basic](/img/gantt_basic.png)
 
-((index
 - [dhtmlxGantt 설치 방법](guides/installation.md)
 - [dhtmlxGantt를 Plain JS/HTML에서 사용하기](guides/initializing-gantt-chart.md)
 - [확장 기능 전체 목록](guides/extensions-list.md)
-))

--- a/i18n/ko/docusaurus-plugin-content-docs/current/guides/loading-storing-data.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/guides/loading-storing-data.md
@@ -7,11 +7,9 @@ sidebar_label: "작업 불러오기 및 저장하기"
 
 ![gantt_basic](/img/gantt_basic.png)
 
-((index
 - [데이터 로딩](guides/loading.md)
 - [동적 로딩 (온디맨드)](guides/dynamic-loading.md)
 - [지원되는 데이터 형식](guides/supported-data-formats.md)
 - [Server-Side Integration](guides/server-side.md)
 - [성능: 개선 방법](guides/performance.md)
 - [백엔드 통합 문제 해결](guides/troubleshooting.md)
-))

--- a/i18n/ko/docusaurus-plugin-content-docs/current/guides/styling.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/guides/styling.md
@@ -5,7 +5,6 @@ sidebar_label: "스타일링"
 
 # 스타일링
 
-((index
 - [CSS 문서](guides/css-overview.md)
 - [스킨(Skins)](guides/skins.md)
 - [스킨 커스터마이제이션](guides/custom-skins.md)
@@ -13,4 +12,3 @@ sidebar_label: "스타일링"
 - [Tasks Coloring](guides/colouring-tasks.md)
 - [링크 색상 및 스타일링](guides/colouring-lines.md)
 - [Gantt 스타일 작업하기](guides/styling-guide.md)
-))

--- a/i18n/ko/docusaurus-plugin-content-docs/current/guides/table.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/guides/table.md
@@ -7,7 +7,6 @@ sidebar_label: "그리드 구성하기"
 
 ![gantt_left](/img/gantt_left.png)
 
-((index
 - [컬럼 지정하기](guides/specifying-columns.md)
 - [그리드에서 행 크기 조정하기](guides/resizing-rows.md)
 - [트리 컬럼 구성하기](guides/tree-column.md)
@@ -16,5 +15,3 @@ sidebar_label: "그리드 구성하기"
 - [작업 그룹화](guides/grouping.md)
 - [작업 필터링](guides/filtering.md)
 - [그리드에서 인라인 편집](guides/inline-editing.md)
-
-))

--- a/i18n/ko/docusaurus-plugin-content-docs/current/guides/task-bars.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/guides/task-bars.md
@@ -7,7 +7,6 @@ sidebar_label: "작업 구성하기"
 
 ![gantt_tasks](/img/gantt_tasks.png)
 
-((index
 - [작업 유형](guides/task-types.md)
 - [Task Properties](guides/task-properties.md)
 - [Task Object/Id](guides/task-object-operations.md)
@@ -28,4 +27,3 @@ sidebar_label: "작업 구성하기"
 - [타임라인 내에서 작업 드래그하기](guides/dnd.md)
 - [DnD로 작업 생성/선택하기](guides/advanced-dnd.md)
 - [수동으로 예약된 요약 작업](guides/custom-projects-dates.md)
-))

--- a/i18n/ko/docusaurus-plugin-content-docs/current/guides/templates.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/guides/templates.md
@@ -8,7 +8,6 @@ sidebar_label: "간트 차트의 템플릿"
 템플릿은 날짜와 라벨의 표시 방식을 사용자 정의할 수 있는 유연성을 제공합니다. 또한 CSS 클래스를 적용하여 간트 차트의 다양한 부분을 스타일링할 수 있습니다.
 
 
-((index
 - [그리드의 템플릿](guides/table-templates.md)
 - [타임라인 영역의 템플릿](guides/timeline-templates.md)
 - [의존성 링크 템플릿](guides/dependency-templates.md)
@@ -16,4 +15,3 @@ sidebar_label: "간트 차트의 템플릿"
 - ['Quick Info' 확장(터치 지원)의 템플릿](guides/touch-templates.md)
 - [툴팁 템플릿](guides/tooltip-templates.md)
 - [날짜 변환을 위한 템플릿](guides/conversion-templates.md)
-))

--- a/i18n/ko/docusaurus-plugin-content-docs/current/guides/time-scale.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/guides/time-scale.md
@@ -7,7 +7,6 @@ sidebar_label: "스케일 설정하기"
 
 ![gantt_right](/img/gantt_right.png)
 
-((index
 - [스케일 설정하기](guides/configuring-time-scale.md) 
 - [줌(Zooming)](guides/zooming.md)
 - [타임 슬롯 하이라이트하기](guides/highlighting-time-slots.md)
@@ -15,4 +14,3 @@ sidebar_label: "스케일 설정하기"
 - [스케일에서 시간 단위 숨기기](guides/custom-scale.md)
 - [수직 마커 추가하기](guides/markers.md)
 - [RTL (오른쪽-왼쪽) 모드](guides/rtl-mode.md)
-))

--- a/i18n/ko/docusaurus-plugin-content-docs/current/guides/work-with-dates.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/guides/work-with-dates.md
@@ -5,7 +5,5 @@ sidebar_label: "날짜 작업하기"
 
 # 날짜 작업하기
 
-((index
 - [날짜 형식 지정](guides/date-format.md)
 - [날짜 작업](guides/date-operations.md)
-))

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/configuring-gantt.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/configuring-gantt.md
@@ -7,7 +7,6 @@ sidebar_label: "Настройка Gantt Chart"
 
 ![gantt_basic](/img/gantt_basic.png)
 
-((index
 - [Конфигурация](guides/common-configuration.md)
 - [Макет Gantt](guides/layout-config.md)
 - [Управление ресурсами](guides/resource-management.md)
@@ -15,4 +14,3 @@ sidebar_label: "Настройка Gantt Chart"
 - [Несколько диаграмм Gantt на одной странице](guides/multiple-gantts.md)
 - [Особенности экземпляра Gantt](guides/gantt-instance.md)
 - [Использование Gantt на сервере](guides/using-gantt-on-server.md)
-))

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/edit-form.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/edit-form.md
@@ -7,10 +7,8 @@ sidebar_label: "Настройка формы редактирования"
 
 ![lightbox](/img/lightbox.png)
 
-((index
 - [Настройка элементов Lightbox](guides/default-edit-form.md)
 - [Работа с элементами Lightbox](guides/lightbox-manipulations.md)
 - [Создание пользовательского элемента](guides/custom-editor.md)
 - [Кастомный Lightbox](guides/custom-edit-form.md)
 - [Изменение кнопок в Lightbox](guides/custom-button.md)
-))

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/export-common.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/export-common.md
@@ -5,7 +5,6 @@ sidebar_label: "Экспорт и импорт данных"
 
 # Экспорт и импорт данных
 
-((index
 - [Экспорт в PDF и PNG](guides/export.md)
 - [Экспорт/Импорт в Excel, экспорт в iCal](guides/excel.md)
 - [Экспорт и импорт из MS Project](guides/export-msproject.md)
@@ -13,4 +12,3 @@ sidebar_label: "Экспорт и импорт данных"
 - [Сериализация данных в XML и JSON](guides/serialization.md)
 - [Экспорт и импорт данных в Node.js](guides/export-nodejs.md)
 - [Модули экспорта](guides/export-modules.md)
-))

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/extra-resources.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/extra-resources.md
@@ -5,7 +5,6 @@ sidebar_label: "Общие возможности"
 
 # Общие возможности
 
-((index
 - [Локализация](guides/localization.md)
 - [Полноэкранный режим](guides/fullscreen-mode.md)
 - [Экран пустого состояния](guides/empty-state-screen.md)
@@ -16,4 +15,3 @@ sidebar_label: "Общие возможности"
 - [Навигация с клавиатуры](guides/keyboard-navigation.md)
 - [Соответствие политике Content Security Policy (CSP)](guides/content-security-policy.md)
 - [Интеграция с JQuery](guides/jquery-integration.md)
-))

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/general-gantt-chart.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/general-gantt-chart.md
@@ -7,8 +7,6 @@ sidebar_label: "Создание диаграммы Gantt на странице"
 
 ![gantt_basic](/img/gantt_basic.png)
 
-((index
 - [Как установить dhtmlxGantt](guides/installation.md)
 - [dhtmlxGantt на чистом JS/HTML](guides/initializing-gantt-chart.md)
 - [Полный список расширений](guides/extensions-list.md)
-))

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/table.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/table.md
@@ -7,7 +7,6 @@ sidebar_label: "Настройка грида"
 
 ![gantt_left](/img/gantt_left.png)
 
-((index
 - [Указание колонок](guides/specifying-columns.md)
 - [Изменение размера строк в гриде](guides/resizing-rows.md)
 - [Настройка древовидной колонки](guides/tree-column.md)
@@ -16,5 +15,3 @@ sidebar_label: "Настройка грида"
 - [Группировка задач](guides/grouping.md)
 - [Фильтрация задач](guides/filtering.md)
 - [Редактирование 'на месте' в гриде](guides/inline-editing.md)
-
-))

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/task-bars.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/task-bars.md
@@ -7,7 +7,6 @@ sidebar_label: "Настройка задач"
 
 ![gantt_tasks](/img/gantt_tasks.png)
 
-((index
 - [Типы задач](guides/task-types.md)
 - [Свойства задачи](guides/task-properties.md)
 - [Task Object/Id](guides/task-object-operations.md)
@@ -28,4 +27,3 @@ sidebar_label: "Настройка задач"
 - [Перетаскивание задач на временной шкале](guides/dnd.md)
 - [Создание/Выделение задач с помощью DnD](guides/advanced-dnd.md)
 - [Вручную запланированные сводные задачи](guides/custom-projects-dates.md)
-))

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/templates.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/templates.md
@@ -8,7 +8,6 @@ sidebar_label: "Шаблоны диаграммы Gantt"
 Шаблоны предоставляют гибкость для настройки отображения дат и меток. Они также позволяют применять CSS-классы для стилизации различных частей диаграммы Gantt.
 
 
-((index
 - [Шаблоны грида](guides/table-templates.md)
 - [Шаблоны области временной шкалы](guides/timeline-templates.md)
 - [Шаблоны связей зависимостей](guides/dependency-templates.md)
@@ -16,4 +15,3 @@ sidebar_label: "Шаблоны диаграммы Gantt"
 - [Шаблоны расширения 'Quick Info' (Поддержка Touch)](guides/touch-templates.md)
 - [Шаблоны тултипов](guides/tooltip-templates.md)
 - [Шаблоны для преобразования дат](guides/conversion-templates.md)
-))

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/time-scale.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/time-scale.md
@@ -7,7 +7,6 @@ sidebar_label: "Настройка шкал"
 
 ![gantt_right](/img/gantt_right.png)
 
-((index
 - [Настройка шкалы](guides/configuring-time-scale.md) 
 - [Масштабирование](guides/zooming.md)
 - [Выделение временных слотов](guides/highlighting-time-slots.md)
@@ -15,4 +14,3 @@ sidebar_label: "Настройка шкал"
 - [Скрытие временных единиц на шкале](guides/custom-scale.md)
 - [Добавление вертикальных маркеров](guides/markers.md)
 - [RTL (Right-to-left) режим](guides/rtl-mode.md)
-))

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/work-with-dates.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/work-with-dates.md
@@ -5,7 +5,5 @@ sidebar_label: "Работа с датами"
 
 # Работа с датами
 
-((index
 - [Спецификация формата даты](guides/date-format.md)
 - [Операции с датами](guides/date-operations.md)
-))

--- a/i18n/zh/docusaurus-plugin-content-docs/current/guides/dependencies.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/guides/dependencies.md
@@ -7,9 +7,7 @@ sidebar_label: "配置依赖关系链接"
 
 ![gantt_arrows](/img/gantt_arrows.png)
 
-((index
 - [링크 속성](guides/link-properties.md)
 - [링크 객체/ID 가져오기](guides/link-object-operations.md)
 - [링크 추가/수정/삭제](guides/crud-dependency.md)
 - [자동 스케줄링](guides/auto-scheduling.md)
-))


### PR DESCRIPTION
https://docs.dhtmlx.com/gantt/ru/guides/export-common/
https://docs.dhtmlx.com/gantt/de/guides/export-common/
https://docs.dhtmlx.com/gantt/ko/guides/export-modules/
https://docs.dhtmlx.com/gantt/ko/guides/export-common/

Removed legacy markup from index pages: https://github.com/DHTMLX/gantt-docs/blob/master/i18n/de/docusaurus-plugin-content-docs/current/guides/export-common.md?plain=1#L8