### PR TITLE
Fix missing links to installation & overview pages

### DIFF
--- a/docs/integrations/react/firebase-integration.md
+++ b/docs/integrations/react/firebase-integration.md
@@ -41,7 +41,7 @@ npm install firebase
 
 ### Installing React Gantt
 
-Install React Gantt as described in [](integrations/react/installation.md).
+Install React Gantt as described in the [React Gantt installation guide](integrations/react/installation.md).
 
 In this tutorial we use the evaluation package:
 

--- a/docs/integrations/react/nextjs.md
+++ b/docs/integrations/react/nextjs.md
@@ -37,7 +37,7 @@ cd react-gantt-nextjs-quick-start
 
 ## Step 1. Installing the React Gantt package
 
-Install React Gantt as described in [](integrations/react/installation.md).
+Install React Gantt as described in the [React Gantt installation guide](integrations/react/installation.md).
 
 In this tutorial we use the evaluation package:
 

--- a/docs/integrations/react/quick-start.md
+++ b/docs/integrations/react/quick-start.md
@@ -32,7 +32,7 @@ cd react-gantt-quick-start
 
 ### Installing React Gantt
 
-Install React Gantt as described in [](integrations/react/installation.md).
+Install React Gantt as described in the [React Gantt installation guide](integrations/react/installation.md).
 
 In this tutorial we use the evaluation package:
 

--- a/docs/integrations/react/remix.md
+++ b/docs/integrations/react/remix.md
@@ -43,7 +43,7 @@ Your application will be available at `http://localhost:5173`.
 
 ## Step 1. Installing the React Gantt package
 
-Install React Gantt as described in [](integrations/react/installation.md).
+Install React Gantt as described in the [React Gantt installation guide](integrations/react/installation.md).
 
 In this tutorial we use the evaluation package:
 

--- a/docs/integrations/react/state/jotai.md
+++ b/docs/integrations/react/state/jotai.md
@@ -43,7 +43,7 @@ Then we need to install the React Gantt package.
 
 ### Installing React Gantt
 
-Install React Gantt as described in [](integrations/react/installation.md).
+Install React Gantt as described in the [React Gantt installation guide](integrations/react/installation.md).
 
 In this tutorial we use the evaluation package:
 
@@ -475,7 +475,7 @@ A complete working project that follows this tutorial is [provided on GitHub](ht
 To go further:
 
 - Revisit the concepts behind this example in [](integrations/react/state/state-management-basics.md)
-- Combine Jotai-driven state with advanced configuration and templating in [](integrations/react/overview.md)
+- Combine Jotai-driven state with advanced configuration and templating in the [React Gantt overview](integrations/react/installation.md)
 - Explore the same pattern with other state managers:
   - [Using React Gantt with Redux Toolkit](integrations/react/state/redux-toolkit.md)
   - [Using React Gantt with MobX](integrations/react/state/mobx.md)

--- a/docs/integrations/react/state/jotai.md
+++ b/docs/integrations/react/state/jotai.md
@@ -475,7 +475,7 @@ A complete working project that follows this tutorial is [provided on GitHub](ht
 To go further:
 
 - Revisit the concepts behind this example in [](integrations/react/state/state-management-basics.md)
-- Combine Jotai-driven state with advanced configuration and templating in the [React Gantt overview](integrations/react/installation.md)
+- Combine Jotai-driven state with advanced configuration and templating in the [React Gantt overview](integrations/react/overview.md)
 - Explore the same pattern with other state managers:
   - [Using React Gantt with Redux Toolkit](integrations/react/state/redux-toolkit.md)
   - [Using React Gantt with MobX](integrations/react/state/mobx.md)

--- a/docs/integrations/react/state/mobx.md
+++ b/docs/integrations/react/state/mobx.md
@@ -45,7 +45,7 @@ Then we need to install the React Gantt package.
 
 ### Installing React Gantt
 
-Install React Gantt as described in [](integrations/react/installation.md).
+Install React Gantt as described in the [React Gantt installation guide](integrations/react/installation.md).
 
 In this tutorial we use the evaluation package:
 
@@ -480,7 +480,7 @@ A complete working project that follows this tutorial is [provided on GitHub](ht
 To go further:
 
 - Revisit the concepts behind this example in [](integrations/react/state/state-management-basics.md)
-- Combine store-driven state with advanced configuration and templating in [](integrations/react/overview.md)
+- Combine store-driven state with advanced configuration and templating in the [React Gantt overview](integrations/react/installation.md)
 - Explore the same pattern with other state managers:
   - [Using React Gantt with Redux Toolkit](integrations/react/state/redux-toolkit.md)
   - [Using React Gantt with Zustand](integrations/react/state/zustand.md)

--- a/docs/integrations/react/state/mobx.md
+++ b/docs/integrations/react/state/mobx.md
@@ -480,7 +480,7 @@ A complete working project that follows this tutorial is [provided on GitHub](ht
 To go further:
 
 - Revisit the concepts behind this example in [](integrations/react/state/state-management-basics.md)
-- Combine store-driven state with advanced configuration and templating in the [React Gantt overview](integrations/react/installation.md)
+- Combine store-driven state with advanced configuration and templating in the [React Gantt overview](integrations/react/overview.md)
 - Explore the same pattern with other state managers:
   - [Using React Gantt with Redux Toolkit](integrations/react/state/redux-toolkit.md)
   - [Using React Gantt with Zustand](integrations/react/state/zustand.md)

--- a/docs/integrations/react/state/redux-toolkit.md
+++ b/docs/integrations/react/state/redux-toolkit.md
@@ -588,7 +588,7 @@ A complete working project that follows this tutorial is [provided on GitHub](ht
 To go further:
 
 - Revisit the concepts behind this example in [](integrations/react/state/state-management-basics.md)
-- Combine Redux-driven state with advanced configuration and templating in the [React Gantt overview](integrations/react/installation.md)
+- Combine Redux-driven state with advanced configuration and templating in the [React Gantt overview](integrations/react/overview.md)
 - Explore the same pattern with other state managers:
   - [Using React Gantt with Zustand](integrations/react/state/zustand.md)
   - [Using React Gantt with MobX](integrations/react/state/mobx.md)

--- a/docs/integrations/react/state/redux-toolkit.md
+++ b/docs/integrations/react/state/redux-toolkit.md
@@ -42,7 +42,7 @@ Then we need to install the React Gantt package.
 
 ### Installing React Gantt
 
-Install React Gantt as described in [](integrations/react/installation.md).
+Install React Gantt as described in the [React Gantt installation guide](integrations/react/installation.md).
 
 In this tutorial we use the evaluation package:
 
@@ -588,7 +588,7 @@ A complete working project that follows this tutorial is [provided on GitHub](ht
 To go further:
 
 - Revisit the concepts behind this example in [](integrations/react/state/state-management-basics.md)
-- Combine Redux-driven state with advanced configuration and templating in [](integrations/react/overview.md)
+- Combine Redux-driven state with advanced configuration and templating in the [React Gantt overview](integrations/react/installation.md)
 - Explore the same pattern with other state managers:
   - [Using React Gantt with Zustand](integrations/react/state/zustand.md)
   - [Using React Gantt with MobX](integrations/react/state/mobx.md)

--- a/docs/integrations/react/state/state-management-basics.md
+++ b/docs/integrations/react/state/state-management-basics.md
@@ -494,5 +494,5 @@ State managers:
 
 Or learn more about usage of imperative API and server-side communication:
 
-- [](integrations/react/configuration-props.md)
+- [React Gantt Configuration](integrations/react/configuration-props.md)
 - [Server-Side Integration](guides/server-side.md)

--- a/docs/integrations/react/state/valtio.md
+++ b/docs/integrations/react/state/valtio.md
@@ -466,7 +466,7 @@ A complete working project that follows this tutorial is [provided on GitHub](ht
 To go further:
 
 - Revisit the concepts behind this example in [](integrations/react/state/state-management-basics.md)
-- Combine store-driven state with advanced configuration and templating in the [React Gantt overview](integrations/react/installation.md)
+- Combine store-driven state with advanced configuration and templating in the [React Gantt overview](integrations/react/overview.md)
 - Explore the same pattern with other state managers:
   - [Using React Gantt with Redux Toolkit](integrations/react/state/redux-toolkit.md)
   - [Using React Gantt with MobX](integrations/react/state/mobx.md)

--- a/docs/integrations/react/state/valtio.md
+++ b/docs/integrations/react/state/valtio.md
@@ -43,7 +43,7 @@ Then we need to install the React Gantt package.
 
 ### Installing React Gantt
 
-Install React Gantt as described in [](integrations/react/installation.md).
+Install React Gantt as described in the [React Gantt installation guide](integrations/react/installation.md).
 
 In this tutorial we use the evaluation package:
 
@@ -466,7 +466,7 @@ A complete working project that follows this tutorial is [provided on GitHub](ht
 To go further:
 
 - Revisit the concepts behind this example in [](integrations/react/state/state-management-basics.md)
-- Combine store-driven state with advanced configuration and templating in [](integrations/react/overview.md)
+- Combine store-driven state with advanced configuration and templating in the [React Gantt overview](integrations/react/installation.md)
 - Explore the same pattern with other state managers:
   - [Using React Gantt with Redux Toolkit](integrations/react/state/redux-toolkit.md)
   - [Using React Gantt with MobX](integrations/react/state/mobx.md)

--- a/docs/integrations/react/state/xstate.md
+++ b/docs/integrations/react/state/xstate.md
@@ -579,7 +579,7 @@ A complete working project that follows this tutorial is [provided on GitHub](ht
 To go further:
 
 - Revisit the concepts behind this example in [](integrations/react/state/state-management-basics.md)
-- Combine XState machine with advanced configuration and templating in the [React Gantt overview](integrations/react/installation.md)
+- Combine XState machine with advanced configuration and templating in the [React Gantt overview](integrations/react/overview.md)
 - Compare this XState-driven architecture with other state managers:
   - [Using React Gantt with Redux Toolkit](integrations/react/state/redux-toolkit.md)
   - [Using React Gantt with MobX](integrations/react/state/mobx.md)

--- a/docs/integrations/react/state/xstate.md
+++ b/docs/integrations/react/state/xstate.md
@@ -43,7 +43,7 @@ Then we need to install the React Gantt package.
 
 ### Installing React Gantt
 
-Install React Gantt as described in [](integrations/react/installation.md).
+Install React Gantt as described in the [React Gantt installation guide](integrations/react/installation.md).
 
 In this tutorial we use the evaluation package:
 
@@ -579,7 +579,7 @@ A complete working project that follows this tutorial is [provided on GitHub](ht
 To go further:
 
 - Revisit the concepts behind this example in [](integrations/react/state/state-management-basics.md)
-- Combine XState machine with advanced configuration and templating in [](integrations/react/overview.md)
+- Combine XState machine with advanced configuration and templating in the [React Gantt overview](integrations/react/installation.md)
 - Compare this XState-driven architecture with other state managers:
   - [Using React Gantt with Redux Toolkit](integrations/react/state/redux-toolkit.md)
   - [Using React Gantt with MobX](integrations/react/state/mobx.md)

--- a/docs/integrations/react/state/zustand.md
+++ b/docs/integrations/react/state/zustand.md
@@ -485,7 +485,7 @@ A complete working project that follows this tutorial is [provided on GitHub](ht
 To go further:
 
 - Revisit the concepts behind this example in [](integrations/react/state/state-management-basics.md)
-- Combine store-driven state with advanced configuration and templating in the [React Gantt overview](integrations/react/installation.md)
+- Combine store-driven state with advanced configuration and templating in the [React Gantt overview](integrations/react/overview.md)
 - Explore the same pattern with other state managers:
   - [Using React Gantt with Redux Toolkit](integrations/react/state/redux-toolkit.md)
   - [Using React Gantt with MobX](integrations/react/state/mobx.md)

--- a/docs/integrations/react/state/zustand.md
+++ b/docs/integrations/react/state/zustand.md
@@ -43,7 +43,7 @@ Then we need to install the React Gantt package.
 
 ### Installing React Gantt
 
-Install React Gantt as described in [](integrations/react/installation.md).
+Install React Gantt as described in the [React Gantt installation guide](integrations/react/installation.md).
 
 In this tutorial we use the evaluation package:
 
@@ -485,7 +485,7 @@ A complete working project that follows this tutorial is [provided on GitHub](ht
 To go further:
 
 - Revisit the concepts behind this example in [](integrations/react/state/state-management-basics.md)
-- Combine store-driven state with advanced configuration and templating in [](integrations/react/overview.md)
+- Combine store-driven state with advanced configuration and templating in the [React Gantt overview](integrations/react/installation.md)
 - Explore the same pattern with other state managers:
   - [Using React Gantt with Redux Toolkit](integrations/react/state/redux-toolkit.md)
   - [Using React Gantt with MobX](integrations/react/state/mobx.md)


### PR DESCRIPTION
Some of links with empty label are not rendered to the page for some reason:

https://docs.dhtmlx.com/gantt/integrations/react/state/zustand/#installing-react-gantt - https://github.com/DHTMLX/gantt-docs/blob/master/docs/integrations/react/state/zustand.md?plain=1#L46 

Adding labels to fix it