### PR TITLE
[add] ai tools section in integrations

### DIFF
--- a/docs/integrations/ai-tools/index.md
+++ b/docs/integrations/ai-tools/index.md
@@ -1,0 +1,9 @@
+---
+title: "AI Tools"
+sidebar_label: "AI Tools"
+---
+
+# AI Tools
+
+This section covers AI tool integrations for DHTMLX Gantt.
+Start here to understand the setup path before using tool-specific guides.

--- a/sidebars.js
+++ b/sidebars.js
@@ -123,6 +123,15 @@ module.exports = {
                 "integrations/angular/howtostart-angular",
                 "integrations/svelte/howtostart-svelte",
                 "integrations/salesforce/howtostart-salesforce",
+                {
+                    type: "category",
+                    label: "AI Tools",
+                    link: {
+                        type: "doc",
+                        id: "integrations/ai-tools/index"
+                    },
+                    items: []
+                },
                 "guides/using-gantt-on-server",
                 {
                     type: "category",
@@ -1556,4 +1565,3 @@ module.exports = {
         }
     ]
 };
-


### PR DESCRIPTION
- add integrations landing page at docs/integrations/ai-tools/index.md
- add AI Tools category in sidebars under Integrations
- link sidebar category to integrations/ai-tools/index