### PR TITLE
[fix] broken doc links in de/ru/ko/zh translations

### DIFF
--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/export-msproject.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/export-msproject.md
@@ -128,7 +128,7 @@ gantt.exportToMSProject({
 ~~~
 
 Die Eigenschaften dieses Objekts entsprechen den entsprechenden Eigenschaften der [Project entity](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)).
-Die Liste der unterstützten Eigenschaften finden Sie [hier](guides/tags.md). Die Eigenschaften können entweder feste Werte oder Funktionen enthalten, die beim Aufruf des Exports ausgeführt werden.
+Die Liste der unterstützten Eigenschaften finden Sie [hier](guides/msp-import-properties.md). Die Eigenschaften können entweder feste Werte oder Funktionen enthalten, die beim Aufruf des Exports ausgeführt werden.
 
 - **tasks** - (object) ermöglicht das Festlegen benutzerdefinierter Eigenschaften für die exportierten Aufgaben
  
@@ -153,7 +153,7 @@ gantt.exportToMSProject({
 ~~~
 
 Die Eigenschaften dieses Objekts entsprechen den entsprechenden Eigenschaften der [Task entity](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)), 
-hier ist eine Liste der unterstützten [Eigenschaften](guides/tags.md#tasks-properties).
+hier ist eine Liste der unterstützten [Eigenschaften](guides/msp-import-properties.md#tasks-properties).
 Die Eigenschaften können entweder feste Werte oder Funktionen enthalten, die für jede Aufgabe im Datensatz beim Export aufgerufen werden.
 
 - **data** - (object) ermöglicht das Festlegen einer benutzerdefinierten Datenquelle, die im output Gantt-Diagramm dargestellt wird
@@ -414,7 +414,7 @@ gantt.importFromMSProject({
 Um Felder des Projekts zu erhalten, kann der Input **projectProperties** mit einem Array der benötigten Felder an den Server gesendet werden.
 Es extrahiert beliebige Eigenschaften der [Project entity](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12))
 in die **config**-Eigenschaft der Ausgabe.
-Hier ist die Liste der unterstützten [Eigenschaften](guides/tags.md#project-properties).
+Hier ist die Liste der unterstützten [Eigenschaften](guides/msp-import-properties.md#project-properties).
 
  - **projectProperties** - gibt ein Array von Projekt-Eigenschaften an, die in die Antwort aufgenommen werden sollen.
 
@@ -446,7 +446,7 @@ gantt.importFromMSProject({
 #### Abfragen von Aufgaben-Eigenschaften
 
 Um Feldwerte der Aufgaben abzurufen, kann der Input **taskProperties** mit einem Array der benötigten Felder an den Server gesendet werden.
-Es extrahiert beliebige Eigenschaften der [Task entities](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)). Hier ist die Liste der unterstützten [Eigenschaften](guides/tags.md#tasks-properties):
+Es extrahiert beliebige Eigenschaften der [Task entities](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)). Hier ist die Liste der unterstützten [Eigenschaften](guides/msp-import-properties.md#tasks-properties):
 
  - **taskProperties** - geben Sie ein Array zusätzlicher Eigenschaften der Aufgaben an, die importiert werden sollen.
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/guides/export-primavera.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/guides/export-primavera.md
@@ -144,7 +144,7 @@ gantt.exportToPrimaveraP6({
 });
 ~~~
 
-Die Eigenschaften dieses Objekts entsprechen den entsprechenden Eigenschaften der [Project entity](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)). Die Liste der unterstützten Eigenschaften finden Sie [hier](guides/properties.md). Die Eigenschaften können feste Werte oder Funktionen enthalten, die beim Aufruf des Exports ausgeführt werden.
+Die Eigenschaften dieses Objekts entsprechen den entsprechenden Eigenschaften der [Project entity](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)). Die Liste der unterstützten Eigenschaften finden Sie [hier](guides/primavera-import-properties.md). Die Eigenschaften können feste Werte oder Funktionen enthalten, die beim Aufruf des Exports ausgeführt werden.
 
 - **tasks** - (object) ermöglicht das Festlegen benutzerdefinierter Eigenschaften für die exportierten Task-Einträge
 
@@ -168,7 +168,7 @@ gantt.exportToPrimaveraP6({
 });
 ~~~
 
-Die Eigenschaften dieses Objekts entsprechen den entsprechenden Eigenschaften der [Task entity](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)), hier finden Sie eine Liste der unterstützten [Eigenschaften](guides/properties.md#tasks-properties). Die Eigenschaften können feste Werte oder Funktionen enthalten, die für jeden Datensatz beim Export aufgerufen werden.
+Die Eigenschaften dieses Objekts entsprechen den entsprechenden Eigenschaften der [Task entity](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)), hier finden Sie eine Liste der unterstützten [Eigenschaften](guides/primavera-import-properties.md#tasks-properties). Die Eigenschaften können feste Werte oder Funktionen enthalten, die für jeden Datensatz beim Export aufgerufen werden.
 
 - **data** - (object) ermöglicht das Festlegen einer benutzerdefinierten Datenquelle, die in der Output-Gantt-Diagramm angezeigt wird.
 
@@ -425,7 +425,7 @@ gantt.importFromPrimaveraP6({
 #### Abrufen von Eigenschaften des Projekts
 
 Um Felder des Projekts abzurufen, kann die Eingabe **projectProperties** mit einem Array der benötigten Felder an den Server gesendet werden.
-Sie extrahiert beliebige Eigenschaften der [Project entity](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)) in die **config**-Eigenschaft der Ausgabe. Hier ist die Liste der unterstützten [Eigenschaften](guides/properties.md#project-properties).
+Sie extrahiert beliebige Eigenschaften der [Project entity](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)) in die **config**-Eigenschaft der Ausgabe. Hier ist die Liste der unterstützten [Eigenschaften](guides/primavera-import-properties.md#project-properties).
 
  - **projectProperties** - gibt ein Array von Projekt-Eigenschaften an, die in die Antwort aufgenommen werden sollen.
 
@@ -457,7 +457,7 @@ gantt.importFromPrimaveraP6({
 #### Abrufen von Aufgaben-Eigenschaften
 
 Um Felder der Aufgaben abzurufen, kann die Eingabe **taskProperties** mit einem Array der benötigten Felder an den Server gesendet werden.
-Sie extrahiert beliebige Eigenschaften der [Task entities](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)). Hier ist die Liste der unterstützten [Eigenschaften](guides/properties.md#tasks-properties):
+Sie extrahiert beliebige Eigenschaften der [Task entities](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)). Hier ist die Liste der unterstützten [Eigenschaften](guides/primavera-import-properties.md#tasks-properties):
 
  - **taskProperties** - geben Sie ein Array zusätzlicher Aufgaben-Eigenschaften an, die importiert werden sollen.
 

--- a/i18n/ko/docusaurus-plugin-content-docs/current/guides/export-msproject.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/guides/export-msproject.md
@@ -121,7 +121,7 @@ gantt.exportToMSProject({
 });
 ~~~
 
-이 객체의 속성은 MS Project의 해당 속성에 대응합니다. 지원되는 속성 목록은 [여기](guides/tags.md)에서 확인할 수 있습니다. 속성은 고정 값이거나 내보내기 호출 시 실행될 함수일 수 있습니다.
+이 객체의 속성은 MS Project의 해당 속성에 대응합니다. 지원되는 속성 목록은 [여기](guides/msp-import-properties.md)에서 확인할 수 있습니다. 속성은 고정 값이거나 내보내기 호출 시 실행될 함수일 수 있습니다.
 
 - **tasks** - (object) 내보낸 작업 항목에 커스텀 속성을 설정합니다.
 
@@ -145,7 +145,7 @@ gantt.exportToMSProject({
 });
 ~~~
 
-이 객체의 속성은 MS Project의 해당 작업 엔티티에 대응합니다. 지원되는 속성 목록은 [여기](guides/tags.md#tasks-properties)에서 확인할 수 있습니다. 속성은 고정 값이거나 내보내기 호출 시 각 작업마다 실행될 함수일 수 있습니다.
+이 객체의 속성은 MS Project의 해당 작업 엔티티에 대응합니다. 지원되는 속성 목록은 [여기](guides/msp-import-properties.md#tasks-properties)에서 확인할 수 있습니다. 속성은 고정 값이거나 내보내기 호출 시 각 작업마다 실행될 함수일 수 있습니다.
 
 - **data** - (object) 출력 Gantt 차트에 표시될 커스텀 데이터 소스를 설정합니다.
 
@@ -394,7 +394,7 @@ gantt.importFromMSProject({
 
 #### 프로젝트 속성 얻기
 
-프로젝트 필드를 얻으려면 필요한 필드들의 배열을 포함하는 projectProperties 입력을 서버로 보낼 수 있습니다. 이는 MS Project 엔티티의 임의 속성을 추출하여 출력의 config 속성에 넣습니다. 지원되는 [속성] 목록은 [여기](guides/tags.md#project-properties)에서 확인할 수 있습니다.
+프로젝트 필드를 얻으려면 필요한 필드들의 배열을 포함하는 projectProperties 입력을 서버로 보낼 수 있습니다. 이는 MS Project 엔티티의 임의 속성을 추출하여 출력의 config 속성에 넣습니다. 지원되는 [속성] 목록은 [여기](guides/msp-import-properties.md#project-properties)에서 확인할 수 있습니다.
 
  - **projectProperties** - 응답에 포함될 프로젝트 속성의 배열을 지정합니다.
 
@@ -425,7 +425,7 @@ gantt.importFromMSProject({
 
 #### 작업 속성 얻기
 
-작업 필드를 얻으려면 필요한 필드들의 배열을 포함하는 taskProperties 입력을 서버로 보낼 수 있습니다. 이는 MS Project Task 엔티티의 임의 속성을 추출합니다. 지원되는 [속성] 목록은 [여기](guides/tags.md#tasks-properties)에서 확인할 수 있습니다:
+작업 필드를 얻으려면 필요한 필드들의 배열을 포함하는 taskProperties 입력을 서버로 보낼 수 있습니다. 이는 MS Project Task 엔티티의 임의 속성을 추출합니다. 지원되는 [속성] 목록은 [여기](guides/msp-import-properties.md#tasks-properties)에서 확인할 수 있습니다:
 
  - **taskProperties** - 가져올 추가 작업 속성의 배열을 지정합니다.
 

--- a/i18n/ko/docusaurus-plugin-content-docs/current/guides/export-primavera.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/guides/export-primavera.md
@@ -144,7 +144,7 @@ gantt.exportToPrimaveraP6({
 });
 ~~~
 
-이 객체의 속성은 [Project 엔티티](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12))의 해당 속성에 대응합니다. 지원되는 속성 목록은 [여기](guides/properties.md)에서 확인할 수 있습니다. 속성은 고정 값이거나 export가 호출될 때 실행될 함수일 수 있습니다.
+이 객체의 속성은 [Project 엔티티](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12))의 해당 속성에 대응합니다. 지원되는 속성 목록은 [여기](guides/primavera-import-properties.md)에서 확인할 수 있습니다. 속성은 고정 값이거나 export가 호출될 때 실행될 함수일 수 있습니다.
 
 - **tasks** - (object) 내보낸 작업 항목에 사용자 정의 속성을 설정합니다
 
@@ -168,7 +168,7 @@ gantt.exportToPrimaveraP6({
 });
 ~~~
 
-이 객체의 속성은 [Task 엔티티](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12))의 해당 속성과 대응합니다. 지원되는 [속성들](guides/properties.md#tasks-properties) 목록은 여기에 있습니다.
+이 객체의 속성은 [Task 엔티티](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12))의 해당 속성과 대응합니다. 지원되는 [속성들](guides/primavera-import-properties.md#tasks-properties) 목록은 여기에 있습니다.
 속성은 고정 값이거나 export 호출 시 각 작업에 대해 실행될 함수일 수 있습니다.
 
 - **data** - (object) 출력 Gantt 차트에 표시될 사용자 정의 데이터 소스를 설정합니다.
@@ -421,7 +421,7 @@ gantt.importFromPrimaveraP6({
 #### 프로젝트 속성 얻기
 
 프로젝트 필드를 얻으려면 서버로 **projectProperties** 배열 입력을 보낼 수 있습니다.
-이는 프로젝트 파일로부터 설정 값을 추출하여 출력의 config 속성에 담습니다. 지원되는 [속성 목록](guides/properties.md#project-properties)을 확인하십시오.
+이는 프로젝트 파일로부터 설정 값을 추출하여 출력의 config 속성에 담습니다. 지원되는 [속성 목록](guides/primavera-import-properties.md#project-properties)을 확인하십시오.
 
  - **projectProperties** - 응답에 포함될 프로젝트 속성의 배열을 지정합니다.
 
@@ -453,7 +453,7 @@ gantt.importFromPrimaveraP6({
 #### 작업 속성 얻기
 
 작업 필드를 얻으려면 **taskProperties** 입력에 필요한 필드 배열을 서버로 보낼 수 있습니다.
-이는 [Task 엔티티](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12))의 임의 속성을 추출합니다. 지원되는 [속성들](guides/properties.md#tasks-properties) 목록은 아래와 같습니다:
+이는 [Task 엔티티](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12))의 임의 속성을 추출합니다. 지원되는 [속성들](guides/primavera-import-properties.md#tasks-properties) 목록은 아래와 같습니다:
 
  - **taskProperties** - 가져올 추가 작업 속성의 배열을 지정합니다.
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/export-msproject.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/export-msproject.md
@@ -130,7 +130,7 @@ gantt.exportToMSProject({
 ~~~
 
 Свойства этого объекта соответствуют соответствующим свойствам [Project entity](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)).
-Список поддерживаемых свойств можно найти [здесь](guides/tags.md). Свойства могут содержать фиксированные значения или функции, которые будут выполнены при вызове экспорта.
+Список поддерживаемых свойств можно найти [здесь](guides/msp-import-properties.md). Свойства могут содержать фиксированные значения или функции, которые будут выполнены при вызове экспорта.
 
 - **tasks** - (object) позволяет задать пользовательские свойства экспортируемых элементов задач
 
@@ -155,7 +155,7 @@ gantt.exportToMSProject({
 ~~~
 
 Свойства этого объекта соответствуют соответствующим свойствам [Task entity](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)), 
-здесь приведён список поддерживаемых [properties](guides/tags.md#tasks-properties).
+здесь приведён список поддерживаемых [properties](guides/msp-import-properties.md#tasks-properties).
 Свойства могут содержать либо фиксированные значения, либо функции, которые будут вызываться для каждой задачи в наборе данных при вызове экспорта.
 
 - **data** - (object) позволяет задать пользовательский источник данных, который будет представлен в выходной диаграмме Gantt
@@ -410,7 +410,7 @@ gantt.importFromMSProject({
 
 Чтобы получить поля проекта, можно отправить на сервер входной параметр **projectProperties** с массивом необходимых полей.
 Он извлекает произвольные свойства [Project entity](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12))
-во входящую в выходной объект конфигурации (**config**). Ниже приведён список поддерживаемых [properties](guides/tags.md#project-properties).
+во входящую в выходной объект конфигурации (**config**). Ниже приведён список поддерживаемых [properties](guides/msp-import-properties.md#project-properties).
 
  - **projectProperties** - задаёт массив свойств проекта, которые должны попасть в ответ.
 
@@ -442,7 +442,7 @@ gantt.importFromMSProject({
 #### Получение свойств задач
 
 Чтобы получить поля задач, можно отправить на сервер входной параметр **taskProperties** с массивом нужных полей.
-Он извлекает произвольные свойства [Task entities](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)). Ниже приводён список поддерживаемых [properties](guides/tags.md#tasks-properties):
+Он извлекает произвольные свойства [Task entities](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)). Ниже приводён список поддерживаемых [properties](guides/msp-import-properties.md#tasks-properties):
 
  - **taskProperties** - указывает массив дополнительных свойств задач, которые нужно импортировать.
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/guides/export-primavera.md
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/guides/export-primavera.md
@@ -145,7 +145,7 @@ gantt.exportToPrimaveraP6({
 });
 ~~~
 
-Свойства этого объекта соответствуют соответствующим свойствам [Project entity](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)). Список поддерживаемых свойств можно найти [здесь](guides/properties.md). Свойства могут содержать либо фиксированные значения, либо функции, которые будут выполняться при вызове экспорта.
+Свойства этого объекта соответствуют соответствующим свойствам [Project entity](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)). Список поддерживаемых свойств можно найти [здесь](guides/primavera-import-properties.md). Свойства могут содержать либо фиксированные значения, либо функции, которые будут выполняться при вызове экспорта.
 
 - **tasks** - (object) позволяет задать дополнительные свойства экспортируемых элементов задач
 
@@ -169,7 +169,7 @@ gantt.exportToPrimaveraP6({
 });
 ~~~
 
-Свойства этого объекта соответствуют соответствующим свойствам [Task entity](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)), ниже приведен список поддерживаемых [properties](guides/properties.md#tasks-properties). Свойства могут содержать либо фиксированные значения, либо функции, которые будут вызываться для каждой задачи в наборе данных при вызове экспорта.
+Свойства этого объекта соответствуют соответствующим свойствам [Task entity](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)), ниже приведен список поддерживаемых [properties](guides/primavera-import-properties.md#tasks-properties). Свойства могут содержать либо фиксированные значения, либо функции, которые будут вызываться для каждой задачи в наборе данных при вызове экспорта.
 
 - **data** - (object) позволяет задать пользовательский источник данных, который будет представлен в выходной диаграмме Gantt. 
 
@@ -426,7 +426,7 @@ gantt.importFromPrimaveraP6({
 
 #### Получение свойств проекта
 
-Чтобы получить поля проекта, на сервер можно отправить входной параметр **projectProperties** с массивом необходимых полей. Он извлекает произвольные свойства сущности [Project](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)) в свойство config выходного файла. Ниже приведен список поддерживаемых [свойств](guides/properties.md#project-properties).
+Чтобы получить поля проекта, на сервер можно отправить входной параметр **projectProperties** с массивом необходимых полей. Он извлекает произвольные свойства сущности [Project](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)) в свойство config выходного файла. Ниже приведен список поддерживаемых [свойств](guides/primavera-import-properties.md#project-properties).
 
  - **projectProperties** - задает массив свойств проекта, которые должны попасть в ответ.
 
@@ -457,7 +457,7 @@ gantt.importFromPrimaveraP6({
 
 #### Получение свойств задач
 
-Чтобы получить поля задач, можно отправить на сервер входной параметр **taskProperties** с массивом необходимых полей. Он извлекает произвольные свойства сущностей [Task](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)). Ниже приведен список поддерживаемых [свойств](guides/properties.md#tasks-properties):
+Чтобы получить поля задач, можно отправить на сервер входной параметр **taskProperties** с массивом необходимых полей. Он извлекает произвольные свойства сущностей [Task](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)). Ниже приведен список поддерживаемых [свойств](guides/primavera-import-properties.md#tasks-properties):
 
  - **taskProperties** - указывает массив дополнительных свойств задач для импорта.
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/guides/export-msproject.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/guides/export-msproject.md
@@ -128,7 +128,7 @@ gantt.exportToMSProject({
 ~~~
 
 该对象的属性对应 [Project 实体](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)) 的相应属性。
-可用属性列表可在 [此处](guides/tags.md) 找到。属性可以包含固定值或在导出调用时将执行的函数。
+可用属性列表可在 [此处](guides/msp-import-properties.md) 找到。属性可以包含固定值或在导出调用时将执行的函数。
 
 - **tasks** - (object) 允许为导出的任务项设置自定义属性
 
@@ -153,7 +153,7 @@ gantt.exportToMSProject({
 ~~~
 
 该对象的属性对应 [Task 实体](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)) 的相应属性，
-这里是支持的 [属性列表](guides/tags.md#tasks-properties)。
+这里是支持的 [属性列表](guides/msp-import-properties.md#tasks-properties)。
 属性可以包含固定值或在导出调用时对每个任务执行的函数。
 
 - **data** - (object) 允许设置一个自定义数据源，将在输出的甘特图中显示
@@ -407,7 +407,7 @@ gantt.importFromMSProject({
 
 要获取项目字段，可以向服务器发送带有所需字段数组的 **projectProperties** 输入。
 它将 [Project 实体](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12))
-的任意属性提取到输出的 config 属性中。下面是支持的 [属性列表](guides/tags.md#project-properties)。
+的任意属性提取到输出的 config 属性中。下面是支持的 [属性列表](guides/msp-import-properties.md#project-properties)。
 
  - **projectProperties** - 指定应放入响应中的项目属性数组。
 
@@ -439,7 +439,7 @@ gantt.importFromMSProject({
 #### 获取任务属性
 
 要获取任务字段，可以向服务器发送带有所需字段数组的 **taskProperties** 输入。
-它将 [Task 实体](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)) 的任意属性提取出来。以下是支持的 [属性列表](guides/tags.md#tasks-properties)：
+它将 [Task 实体](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)) 的任意属性提取出来。以下是支持的 [属性列表](guides/msp-import-properties.md#tasks-properties)：
 
  - **taskProperties** - 指定要导入的附加任务属性数组。
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/guides/export-primavera.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/guides/export-primavera.md
@@ -147,7 +147,7 @@ gantt.exportToPrimaveraP6({
 });
 ~~~
 
-该对象的属性对应 [Project entity] 的相应属性。支持的属性列表可在 [这里](guides/properties.md) 找到。属性可以包含固定值或在导出调用时执行的函数。
+该对象的属性对应 [Project entity] 的相应属性。支持的属性列表可在 [这里](guides/primavera-import-properties.md) 找到。属性可以包含固定值或在导出调用时执行的函数。
 
 - **tasks** - (object) 允许为导出的任务项设置自定义属性
 
@@ -427,7 +427,7 @@ gantt.importFromPrimaveraP6({
 #### 获取项目属性
 
 要获取项目字段，可以向服务器发送带有所需字段数组的 **projectProperties** 输入。
-它将 [Project entity](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)) 的任意属性提取到输出的 config 属性中。支持的 [properties](guides/properties.md#project-properties) 列表如下。
+它将 [Project entity](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)) 的任意属性提取到输出的 config 属性中。支持的 [properties](guides/primavera-import-properties.md#project-properties) 列表如下。
 
  - **projectProperties** - 指定应放入响应中的项目属性数组。
 
@@ -459,7 +459,7 @@ gantt.importFromPrimaveraP6({
 #### 获取任务属性
 
 要获取任务字段，可以向服务器发送带有必要字段的 **taskProperties** 输入。
-它将 [Task entities](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)) 的任意属性提取到输出中的任务属性。下面是 [properties](guides/properties.md#tasks-properties) 的支持列表：
+它将 [Task entities](https://learn.microsoft.com/en-us/previous-versions/office/developer/office-2007/bb968652(v=office.12)) 的任意属性提取到输出中的任务属性。下面是 [properties](guides/primavera-import-properties.md#tasks-properties) 的支持列表：
 
  - **taskProperties** - 指定要导入的额外任务属性数组。
 


### PR DESCRIPTION
- export-msproject.md linked to removed guides/tags.md, now points to guides/msp-import-properties.md
- export-primavera.md linked to removed guides/properties.md, now points to guides/primavera-import-properties.md
- stale targets remained after EN docs split properties into per-module files; anchors (#project-properties, #tasks-properties) unchanged