### PR TITLE
[update] convert export API tables to markdown, add raw param

### DIFF
--- a/docs/api/method/exporttoexcel.md
+++ b/docs/api/method/exporttoexcel.md
@@ -26,6 +26,7 @@ gantt.exportToExcel({
         { id: "start_date",  header: "Start date", width: 250, type: "date" }
     ],
     server: "https://myapp.com/myexport/gantt",
+    raw: true,
     callback: (res) => {
         alert(res.url);
     },
@@ -46,7 +47,7 @@ Read the details in the [](guides/excel.md) article.
 :::note
 If you use the Gantt version older than 8.0, you need to include the `https://export.dhtmlx.com/gantt/api.js` on your page to enable the online export service, e.g.:
 
-~~~js
+~~~html
 <script src="codebase/dhtmlxgantt.js"></script>
 <script src="https://export.dhtmlx.com/gantt/api.js"></script>
 ~~~
@@ -55,40 +56,39 @@ If you use the Gantt version older than 8.0, you need to include the `https://ex
 
 The **exportToExcel()** method takes as a parameter an object with several properties (all the properties are optional):
 
-- **name** - (*string*) sets the name of the output file with the extension '.xlsx' 
-- **columns** - (*array*) allows configuring columns of the output Excel sheet. The properties of the column objects are:
-    - **'id'** - (*string,number*) a property of the event that will be mapped to the column
-    - **'header'** - (*string*) the column header
-    - **'width'** - (*number*) the column width in pixels
-    - **'type'** - (*string*) the column type
-- **server** - (*string*) sets the API endpoint for the request. Can be used with the local install of the export service. The default value is `https://export.dhtmlx.com/gantt`
-- **callback** - (*function*) If you want to receive an url to download a generated XLSX file, the callback property can be used. It receives a JSON object with the url property
-- **visual** - (*boolean*) adds the timeline chart to an exported Excel document; *false* by default. Read [how to add task colors](guides/excel.md#adding-colors-of-tasks-to-export) to the exported file
-- **cellColors** - (*boolean*) if set to *true*, the cells of the exported document will have the colors defined by the [](api/template/timeline_cell_class.md) template, the *color* and *background-color* 
-properties are exported
-- **data** - (*object*) sets a custom data source that will be presented in the output Gantt chart
-- **date_format** - (*string*) sets the format the date will be displayed in the exported Excel document. The following format code can be used:
+| Property | Description |
+| --- | --- |
+| **name** | (*string*) sets the name of the output file with the extension '.xlsx' |
+| **columns** | (*array*) allows configuring columns of the output Excel sheet. The properties of the column objects are:<ul><li><b>'id'</b> - (<i>string,number</i>) a property of the event that will be mapped to the column</li><li><b>'header'</b> - (<i>string</i>) the column header</li><li><b>'width'</b> - (<i>number</i>) the column width in pixels</li><li><b>'type'</b> - (<i>string</i>) the column type</li></ul> |
+| **server** | (*string*) sets the API endpoint for the request. Can be used with the local install of the export service. The default value is `https://export.dhtmlx.com/gantt` |
+| **raw** | (*boolean*) defines the way Gantt data is exported. It performs two tasks:<ul><li>if a task is filtered out via the [`onBeforeTaskDisplay`](api/event/onbeforetaskdisplay.md) event, i.e. isn't displayed in the grid or in the timeline, it isn't exported into the Excel file (by default, all the tasks are exported). <br/> **Related sample**: [Gantt. Export filtered data to PDF, Excel, and MSProject files](https://snippet.dhtmlx.com/twfy116w)</li><li>if a column is [hidden](guides/specifying-columns.md#visibility) via the `hide:true` setting, it isn't exported into the Excel file (all the columns are exported by default). <br/> **Related sample**: [Gantt. Export to Excel. Hide grid columns with the raw mode](https://snippet.dhtmlx.com/b7y0ps8m)</li></ul> *false* by default. [Read the details](guides/excel.md#exporting-filtered-tasks-and-hidden-columns) |
+| **callback** | (*function*) If you want to receive an url to download a generated XLSX file, the callback property can be used. It receives a JSON object with the url property |
+| **visual** | (*boolean*) adds the timeline chart to an exported Excel document; *false* by default. Read [how to add task colors](guides/excel.md#adding-colors-of-tasks-to-export) to the exported file |
+| **cellColors** | (*boolean*) if set to *true*, the cells of the exported document will have the colors defined by the [](api/template/timeline_cell_class.md) template, the *color* and *background-color* properties are exported |
+| **data** | (*object*) sets a custom data source that will be presented in the output Gantt chart |
+| **date_format** | (*string*) sets the format the date will be displayed in the exported Excel document. The following format code can be used: |
 
-Format codeOutput:
+<div class="auto-width-table">
 
-<table class="my_table">
-<tr><td class="version_info">Format code</td><td class="version_info">Output</td></tr>
-<tr><td>d</td><td>9</td></tr>
-<tr><td>dd</td><td>09</td></tr>
-<tr><td>ddd</td><td>Mon</td></tr>
-<tr><td>dddd</td><td>Monday</td></tr>
-<tr><td>mm</td><td>01</td></tr>
-<tr><td>mmm</td><td>Jan</td></tr>
-<tr><td>mmmm</td><td>January</td></tr>
-<tr><td>mmmmm</td><td>J</td></tr>
-<tr><td>yy</td><td>12</td></tr>
-<tr><td>yyyy</td><td>2021</td></tr>
-<tr><td>mm/dd/yyyy</td><td>01/09/2021</td></tr>
-<tr><td>m/d/y</td><td>1/9/21</td></tr>
-<tr><td>ddd, mmm d</td><td>Mon, Jan 9</td></tr>
-<tr><td>mm/dd/yyyy h:mm AM/PM</td><td>01/09/2021 6:20 PM</td></tr>
-<tr><td>dd/mm/yyyy hh:mm:ss</td><td>09/01/2012 16:20:00</td></tr>
-</table>
+| Format code           | Output              |
+| --------------------- | ------------------- |
+| d                     | 9                   |
+| dd                    | 09                  |
+| ddd                   | Mon                 |
+| dddd                  | Monday              |
+| mm                    | 01                  |
+| mmm                   | Jan                 |
+| mmmm                  | January             |
+| mmmmm                 | J                   |
+| yy                    | 12                  |
+| yyyy                  | 2021                |
+| mm/dd/yyyy            | 01/09/2021          |
+| m/d/y                 | 1/9/21              |
+| ddd, mmm d            | Mon, Jan 9          |
+| mm/dd/yyyy h:mm AM/PM | 01/09/2021 6:20 PM  |
+| dd/mm/yyyy hh:mm:ss   | 09/01/2012 16:20:00 |
+
+</div>
 
 
 #### Default date parameters

--- a/docs/api/method/exporttoical.md
+++ b/docs/api/method/exporttoical.md
@@ -29,7 +29,7 @@ gantt.exportToICal({
 :::note
 This method is defined in the **export** extension, so you need to activate the [export_api](guides/extensions-list.md#export-service) plugin. Read the details in the [Export/Import for Excel, Export to iCal](guides/excel.md) article.
 
-~~~js
+~~~html
 <script src="codebase/dhtmlxgantt.js"></script>
 <script src="https://export.dhtmlx.com/gantt/api.js"></script>
 ~~~
@@ -42,6 +42,7 @@ The **exportToICal()** method takes as a parameter an object with the following 
 - **name** - (*string*) allows specifying custom name and extension for the file but the file will still be exported in the iCal format. [Check the example](https://snippet.dhtmlx.com/atbhz9vq).
 
 ### Related API
+
 - [exportToMSProject](api/method/exporttomsproject.md)
 - [exportToPrimaveraP6](api/method/exporttoprimaverap6.md)
 - [exportToExcel](api/method/exporttoexcel.md)
@@ -53,5 +54,6 @@ The **exportToICal()** method takes as a parameter an object with the following 
 - [importFromMSProject](api/method/importfrommsproject.md)
 
 ### Related Guides
+
 - [Export/Import for Excel, Export to iCal](guides/excel.md#export-to-ical)
 

--- a/docs/api/method/exporttojson.md
+++ b/docs/api/method/exporttojson.md
@@ -33,7 +33,7 @@ This method is defined in the **export** extension, so you need to activate the 
 :::note
 note If you use the Gantt version older than 8.0, you need to include the `https://export.dhtmlx.com/gantt/api.js` on your page to enable the online export service, e.g.:
 
-~~~js
+~~~html
 <script src="codebase/dhtmlxgantt.js"></script>
 <script src="https://export.dhtmlx.com/gantt/api.js"></script>
 ~~~
@@ -46,6 +46,7 @@ The **config** object can contain following options:
 - data - (array) list of tasks to be exported. The whole gantt will be exported if not specified
 
 ### Related API
+
 - [exportToMSProject](api/method/exporttomsproject.md)
 - [exportToPrimaveraP6](api/method/exporttoprimaverap6.md)
 - [exportToExcel](api/method/exporttoexcel.md)

--- a/docs/api/method/exporttomsproject.md
+++ b/docs/api/method/exporttomsproject.md
@@ -33,7 +33,7 @@ This method is defined in the **export** extension, so you need to activate the 
 :::note
 note If you use the Gantt version older than 8.0, you need to include the `https://export.dhtmlx.com/gantt/api.js` on your page to enable the online export service, e.g.:
 
-~~~js
+~~~html
 <script src="codebase/dhtmlxgantt.js"></script>
 <script src="https://export.dhtmlx.com/gantt/api.js"></script>
 ~~~
@@ -43,16 +43,17 @@ note If you use the Gantt version older than 8.0, you need to include the `https
 
 The **exportToMSProject()** method takes as a parameter an object with a number of properties (all of the properties are optional):
 
-- **name** - (*string*) the name of the obtained file ('gantt.xml' by default).
-- **auto_scheduling** - (*boolean*) indicates the scheduling mode for tasks in the exported project. **true** will mark tasks as auto scheduled, **false** will mark tasks as manually scheduled (the default state).
-- **skip_circular_links** - (*boolean*) indicates whether the circular links will be removed or not (true - will be removed (the default mode), false - will not be removed).
-- **project** - (*object*) allows setting custom properties to the exported project entity.
-- **tasks** - (*object*) allows setting custom properties to the exported task items.
-- **data** - (*object*) allows setting a custom data source that will be presented in the output Gantt chart. It is expected that the **start_date** and **end_date** properties will be specified in the format which includes both the date and time (*%d-%m-%Y %H:%i*).
-- **callback** - (*function*) if you want to receive an url to download a generated XML, the *callback* property can be used. It receives a JSON object with the *url* property.
-- **resources** - (*array*) allows exporting the list of resources into an MS Project file. If the resource calendars are used, you need to specify -1 for a task in the *CalendarUID* property during the export (in the **tasks** object). 
-Then the task will use the resource calendar.
-- **server** - (*string*) the API endpoint for the request. Can be used with the local install of the export service. The default value is `https://export.dhtmlx.com/gantt`.
+| Property | Description |
+| --- | --- |
+| **name** | (*string*) the name of the obtained file ('gantt.xml' by default). |
+| **auto_scheduling** | (*boolean*) indicates the scheduling mode for tasks in the exported project. **true** will mark tasks as auto scheduled, **false** will mark tasks as manually scheduled (the default state). |
+| **skip_circular_links** | (*boolean*) indicates whether the circular links will be removed or not (true - will be removed (the default mode), false - will not be removed). |
+| **project** | (*object*) allows setting custom properties to the exported project entity. |
+| **tasks** | (*object*) allows setting custom properties to the exported task items. |
+| **data** | (*object*) allows setting a custom data source that will be presented in the output Gantt chart. It is expected that the **start_date** and **end_date** properties will be specified in the format which includes both the date and time (*%d-%m-%Y %H:%i*). |
+| **callback** | (*function*) if you want to receive an url to download a generated XML, the *callback* property can be used. It receives a JSON object with the *url* property. |
+| **resources** | (*array*) allows exporting the list of resources into an MS Project file. If the resource calendars are used, you need to specify -1 for a task in the *CalendarUID* property during the export (in the **tasks** object). Then the task will use the resource calendar. |
+| **server** | (*string*) the API endpoint for the request. Can be used with the local install of the export service. The default value is `https://export.dhtmlx.com/gantt`. |
 
 Check the detailed descriptions of the export settings in the [related section](guides/export-msproject.md#export-settings).
 

--- a/docs/api/method/exporttopdf.md
+++ b/docs/api/method/exporttopdf.md
@@ -52,7 +52,7 @@ This method is defined in the **export** extension, so you need to activate the 
 :::note
 note If you use the Gantt version older than 8.0, you need to include the `https://export.dhtmlx.com/gantt/api.js` on your page to enable the online export service, e.g.:
 
-~~~js
+~~~html
 <script src="codebase/dhtmlxgantt.js"></script>
 <script src="https://export.dhtmlx.com/gantt/api.js"></script>
 ~~~
@@ -62,59 +62,20 @@ note If you use the Gantt version older than 8.0, you need to include the `https
 
 The [](api/method/exporttopdf.md) method takes as a parameter an object with a number of properties (all of the properties are optional):
 
- <table class="webixdoc_links">
-	<tbody>
-  	<tr>
-			<td class="webixdoc_links0"><b>name</b></td>
-			<td>(<i>string</i>) the name of the output file</td>
-		</tr>
-  <tr>
-			<td class="webixdoc_links0"><b>skin</b></td>
-			<td>(<i>'terrace', 'skyblue', 'meadow', 'broadway'</i>) the skin of the output Gantt chart</td>
-		</tr>
-  <tr>
-			<td class="webixdoc_links0"><b>locale</b></td>
-			<td>(<i>string</i>) sets the language that will be used in the output Gantt chart</td>
-		</tr> 
-  <tr>
-			<td class="webixdoc_links0"><b>start</b></td>
-			<td>(<i>string</i>) sets the start date of the data range that will be presented in the output Gantt chart. The date format is defined by the [](api/config/date_format.md) config</td>
-		</tr>
-  <tr>
-			<td class="webixdoc_links0"><b>end</b></td>
-			<td>(<i>string</i>) sets the end date of the data range that will be presented in the output Gantt chart. The date format is defined by the [](api/config/date_format.md) config</td>
-		</tr>
-  <tr>
-			<td class="webixdoc_links0"><b>data</b></td>
-			<td>(<i>object</i>) sets a custom data source that will be presented in the output Gantt chart </td>
-		</tr>
-  <tr>
-			<td class="webixdoc_links0"><b>header</b></td>
-			<td>(<i>string</i>) specifies the header that will be added to the output PDF image. Note, you can use any HTML here</td>
-		</tr>
-  <tr>
-			<td class="webixdoc_links0"><b>footer</b></td>
-			<td>(<i>string</i>) specifies the footer that will be added to the output PDF image. Note, you can use any HTML here</td>
-		</tr>
-  <tr>
-			<td class="webixdoc_links0"><b>server</b></td>
-			<td>(<i>string</i>) sets the API endpoint for the request. Can be used with the local install of the export service. The default value is `https://export.dhtmlx.com/gantt`</td>
-		</tr>
-  <tr>
-			<td class="webixdoc_links0"><b>raw</b></td>
-			<td>(<i>boolean</i>) defines that all Gantt markup will be exported as it is, with all custom elements. <em>false</em> by default. 
-  	[Read the details](guides/export.md#exportingcustommarkupandstyles)</td>
-		</tr>
-		<tr>
-			<td class="webixdoc_links0"><b>callback</b></td>
-			<td>(<i>function</i>) If you want to receive an url to download a generated PDF file, the callback property can be used. It receives a JSON object with the url property</td>
-		</tr>
-		<tr>
-			<td class="webixdoc_links0"><b>additional_settings</b></td>
-			<td>(<i>object</i>) an object with additional settings. The object can contain the following attributes:<ul><li><b>format</b> - (<i>string</i>) the format of the output file:<i>"A0", "A1", "A2", "A3", "A4", "A5", "A6", "Legal", "Ledger", "Letter", "Tabloid"</i></li><li><b>landscape</b> - (<i>boolean</i>) the portrait or landscape orientation of the output file. The attribute works only when the "format" attribute is specified</li><li><b>width</b> - (<i>string|number|"content"</i>) the width of the output page. The attribute is used when exporting multiple pages</li><li><b>height</b> - (<i>string|number|"content"</i>) the height of the output page. The attribute is used when exporting multiple pages</li><li><b>merge_pages</b> - (<i>boolean</i>) enables the <a href="#multi-page-export">multipage export</a> in one file; if set to <i>false</i> you will have to make export several times to get all the Gantt data</li><li><b>fixed_headers</b> - (<i>boolean</i>) enables displaying of the grid and timeline headers on each page; <i>false</i> by default. Works only with the enabled <b>merge_pages</b> setting</li><li><b>margins</b> - (<i>object</i>) the object with the top, bottom, left and right margins for the output PDF file. [Read the details](guides/export.md#margins-of-the-output-pdf-file)</li><li><b>header</b> - (<i>string</i>) specifies the header that will be added to each page of the output PDF file. [Read the details](guides/export.md#headerfooter-of-the-output-file)</li><li><b>footer</b> - (<i>string</i>) specifies the footer that will be added to each page of the output PDF file. [Read the details](guides/export.md#headerfooter-of-the-output-file)</li></ul></td>
-		</tr>
-  </tbody>
-</table>
+| Property | Description |
+| --- | --- |
+| **name** | (*string*) the name of the output file |
+| **skin** | (*'terrace', 'skyblue', 'meadow', 'broadway'*) the skin of the output Gantt chart |
+| **locale** | (*string*) sets the language that will be used in the output Gantt chart |
+| **start** | (*string*) sets the start date of the data range that will be presented in the output Gantt chart. The date format is defined by the [](api/config/date_format.md) config |
+| **end** | (*string*) sets the end date of the data range that will be presented in the output Gantt chart. The date format is defined by the [](api/config/date_format.md) config |
+| **data** | (*object*) sets a custom data source that will be presented in the output Gantt chart |
+| **header** | (*string*) specifies the header that will be added to the output PDF image. Note, you can use any HTML here |
+| **footer** | (*string*) specifies the footer that will be added to the output PDF image. Note, you can use any HTML here |
+| **server** | (*string*) sets the API endpoint for the request. Can be used with the local install of the export service. The default value is `https://export.dhtmlx.com/gantt` |
+| **raw** | (*boolean*) defines that all Gantt markup will be exported as it is, with all custom elements. *false* by default. [Read the details](guides/export.md#exportingcustommarkupandstyles) |
+| **callback** | (*function*) If you want to receive an url to download a generated PDF file, the callback property can be used. It receives a JSON object with the url property |
+| **additional_settings** | (*object*) an object with additional settings. The object can contain the following attributes:<ul><li><b>format</b> - (<i>string</i>) the format of the output file: <i>"A0", "A1", "A2", "A3", "A4", "A5", "A6", "Legal", "Ledger", "Letter", "Tabloid"</i></li><li><b>landscape</b> - (<i>boolean</i>) the portrait or landscape orientation of the output file. The attribute works only when the "format" attribute is specified</li><li><b>width</b> - (<i>string\|number\|"content"</i>) the width of the output page. The attribute is used when exporting multiple pages</li><li><b>height</b> - (<i>string\|number\|"content"</i>) the height of the output page. The attribute is used when exporting multiple pages</li><li><b>merge_pages</b> - (<i>boolean</i>) enables the [multipage export](#multi-page-export) in one file; if set to <i>false</i> you will have to make export several times to get all the Gantt data</li><li><b>fixed_headers</b> - (<i>boolean</i>) enables displaying of the grid and timeline headers on each page; <i>false</i> by default. Works only with the enabled <b>merge_pages</b> setting</li><li><b>margins</b> - (<i>object</i>) the object with the top, bottom, left and right margins for the output PDF file. [Read the details](guides/export.md#margins-of-the-output-pdf-file)</li><li><b>header</b> - (<i>string</i>) specifies the header that will be added to each page of the output PDF file. [Read the details](guides/export.md#headerfooter-of-the-output-file)</li><li><b>footer</b> - (<i>string</i>) specifies the footer that will be added to each page of the output PDF file. [Read the details](guides/export.md#headerfooter-of-the-output-file)</li></ul> |
 
 ### Time restrictions
 

--- a/docs/api/method/exporttopng.md
+++ b/docs/api/method/exporttopng.md
@@ -53,7 +53,7 @@ This method is defined in the **export** extension, so you need to activate the 
 :::note
 If you use the Gantt version older than 8.0, you need to include the `https://export.dhtmlx.com/gantt/api.js` on your page to enable the online export service, e.g.:
 
-~~~js
+~~~html
 <script src="codebase/dhtmlxgantt.js"></script>
 <script src="https://export.dhtmlx.com/gantt/api.js"></script>
 ~~~
@@ -62,59 +62,20 @@ If you use the Gantt version older than 8.0, you need to include the `https://ex
 
 The [](api/method/exporttopng.md) method takes as a parameter an object with a number of properties (all of the properties are optional):
 
-<table class="webixdoc_links">
-	<tbody>
-  	<tr>
-			<td class="webixdoc_links0"><b>name</b></td>
-			<td>(<i>string</i>) the name of the output file</td>
-		</tr>
-  <tr>
-			<td class="webixdoc_links0"><b>skin</b></td>
-			<td>(<i>'terrace', 'skyblue', 'meadow', 'broadway'</i>) the skin of the output Gantt chart</td>
-		</tr>
-  <tr>
-			<td class="webixdoc_links0"><b>locale</b></td>
-			<td>(<i>string</i>) sets the language that will be used in the output Gantt chart</td>
-		</tr> 
-  <tr>
-			<td class="webixdoc_links0"><b>start</b></td>
-			<td>(<i>string</i>) sets the start date of the data range that will be presented in the output Gantt chart. The date format is defined by the [](api/config/date_format.md) config</td>
-		</tr>
-  <tr>
-			<td class="webixdoc_links0"><b>end</b></td>
-			<td>(<i>string</i>) sets the end date of the data range that will be presented in the output Gantt chart. The date format is defined by the [](api/config/date_format.md) config</td>
-		</tr>
-  <tr>
-			<td class="webixdoc_links0"><b>data</b></td>
-			<td>(<i>object</i>) sets a custom data source that will be presented in the output Gantt chart </td>
-		</tr>
-  <tr>
-			<td class="webixdoc_links0"><b>header</b></td>
-			<td>(<i>string</i>) specifies the header that will be added to the output PDF image. Note, you can use any HTML here</td>
-		</tr>
-  <tr>
-			<td class="webixdoc_links0"><b>footer</b></td>
-			<td>(<i>string</i>) specifies the footer that will be added to the output PDF image. Note, you can use any HTML here</td>
-		</tr>
-  <tr>
-			<td class="webixdoc_links0"><b>server</b></td>
-			<td>(<i>string</i>) sets the API endpoint for the request. Can be used with the local install of the export service. The default value is `https://export.dhtmlx.com/gantt`</td>
-		</tr>
-  <tr>
-			<td class="webixdoc_links0"><b>raw</b></td>
-			<td>(<i>boolean</i>) defines that all Gantt markup will be exported as it is, with all custom elements. <em>false</em> by default. [Read the details](guides/export.md#exportingcustommarkupandstyles) </td>
-		</tr>
-		<tr>
-			<td class="webixdoc_links0"><b>callback</b></td>
-			<td>(<i>function</i>) If you want to receive an url to download a generated PNG file, the callback property can be used. It receives a JSON object with the url property</td>
-		</tr>
-		<tr>
-			<td class="webixdoc_links0"><b>additional_settings</b></td>
-			<td>(<i>object</i>) an object with additional settings. The object can contain the following attributes:
-			<ul><li><b>width</b> - (<i>number|string</i>) the width of the output page</li><li><b>height</b> - (<i>number|string</i>) the height of the output page</li>The <b>width</b> and <b>height</b> parameters will be ignored if <b>slice_archive</b> is specified.<li><b>slice_archive</b> - (<i>boolean|object</i>) allows saving large chart by pieces and obtaining them in the archive. As an object, the attribute takes the <b>width</b> and <b>height</b> options. If the piece size is not defined (i.e. <i>slice_archive: true</i>), the default sizes are 1000×1000. </li><li><b>slice_check</b> - (<i>boolean</i>) adds an HTML page to the archive. The page lets you check that all pieces are exported correctly.</li></ul></td>
-		</tr>
-  </tbody>
-</table>
+| Property | Description |
+| --- | --- |
+| **name** | (*string*) the name of the output file |
+| **skin** | (*'terrace', 'skyblue', 'meadow', 'broadway'*) the skin of the output Gantt chart |
+| **locale** | (*string*) sets the language that will be used in the output Gantt chart |
+| **start** | (*string*) sets the start date of the data range that will be presented in the output Gantt chart. The date format is defined by the [](api/config/date_format.md) config |
+| **end** | (*string*) sets the end date of the data range that will be presented in the output Gantt chart. The date format is defined by the [](api/config/date_format.md) config |
+| **data** | (*object*) sets a custom data source that will be presented in the output Gantt chart |
+| **header** | (*string*) specifies the header that will be added to the output PDF image. Note, you can use any HTML here |
+| **footer** | (*string*) specifies the footer that will be added to the output PDF image. Note, you can use any HTML here |
+| **server** | (*string*) sets the API endpoint for the request. Can be used with the local install of the export service. The default value is `https://export.dhtmlx.com/gantt` |
+| **raw** | (*boolean*) defines that all Gantt markup will be exported as it is, with all custom elements. *false* by default. [Read the details](guides/export.md#exportingcustommarkupandstyles) |
+| **callback** | (*function*) If you want to receive an url to download a generated PNG file, the callback property can be used. It receives a JSON object with the url property |
+| **additional_settings** | (*object*) an object with additional settings. The object can contain the following attributes:<ul><li><b>width</b> - (<i>number\|string</i>) the width of the output page</li><li><b>height</b> - (<i>number\|string</i>) the height of the output page</li>The <b>width</b> and <b>height</b> parameters will be ignored if <b>slice_archive</b> is specified.<li><b>slice_archive</b> - (<i>boolean\|object</i>) allows saving large chart by pieces and obtaining them in the archive. As an object, the attribute takes the <b>width</b> and <b>height</b> options. If the piece size is not defined (i.e. <i>slice_archive: true</i>), the default sizes are 1000×1000.</li><li><b>slice_check</b> - (<i>boolean</i>) adds an HTML page to the archive. The page lets you check that all pieces are exported correctly.</li></ul> |
 
 ## Exporting large Gantt by pieces
 

--- a/docs/api/method/exporttoprimaverap6.md
+++ b/docs/api/method/exporttoprimaverap6.md
@@ -37,7 +37,7 @@ This method is defined in the **export** extension, so you need to activate the 
 :::note
 If you use the Gantt version older than 8.0, you need to include the `https://export.dhtmlx.com/gantt/api.js` on your page to enable the online export service, e.g.:
 
-~~~js
+~~~html
 <script src="codebase/dhtmlxgantt.js"></script>
 <script src="https://export.dhtmlx.com/gantt/api.js"></script>
 ~~~
@@ -48,16 +48,17 @@ If you use the Gantt version older than 8.0, you need to include the `https://ex
 
 The **exportToPrimaveraP6()** method takes as a parameter an object with a number of properties (all of the properties are optional):
 
-- **name** - (*string*) the name of the obtained file ('gantt.xml' by default).
-- **auto_scheduling** - (*boolean*) indicates the scheduling mode for tasks in the exported project. **true** will mark tasks as auto scheduled, **false** will mark tasks as manually scheduled (the default state).
-- **skip_circular_links** - (*boolean*) indicates whether the circular links will be removed or not (true - will be removed (the default mode), false - will not be removed).
-- **project** - (*object*) allows setting custom properties to the exported project entity.
-- **tasks** - (*object*) allows setting custom properties to the exported task items.
-- **data** - (*object*) allows setting a custom data source that will be presented in the output Gantt chart. It is expected that the **start_date** and **end_date** properties will be specified in the format which includes both the date and time (*%d-%m-%Y %H:%i*).
-- **callback** - (*function*) if you want to receive an url to download a generated XML, the *callback* property can be used. It receives a JSON object with the *url* property.
-- **resources** - (*array*) allows exporting the list of resources into a Primavera P6 file. If the resource calendars are used, you need to specify -1 for a task
-in the *CalendarUID* property during the export (in the **tasks** object). Then the task will use the resource calendar.
-- **server** - (*string*) the API endpoint for the request. Can be used with the local install of the export service. The default value is `https://export.dhtmlx.com/gantt`.
+| Property | Description |
+| --- | --- |
+| **name** | (*string*) the name of the obtained file ('gantt.xml' by default). |
+| **auto_scheduling** | (*boolean*) indicates the scheduling mode for tasks in the exported project. **true** will mark tasks as auto scheduled, **false** will mark tasks as manually scheduled (the default state). |
+| **skip_circular_links** | (*boolean*) indicates whether the circular links will be removed or not (true - will be removed (the default mode), false - will not be removed). |
+| **project** | (*object*) allows setting custom properties to the exported project entity. |
+| **tasks** | (*object*) allows setting custom properties to the exported task items. |
+| **data** | (*object*) allows setting a custom data source that will be presented in the output Gantt chart. It is expected that the **start_date** and **end_date** properties will be specified in the format which includes both the date and time (*%d-%m-%Y %H:%i*). |
+| **callback** | (*function*) if you want to receive an url to download a generated XML, the *callback* property can be used. It receives a JSON object with the *url* property. |
+| **resources** | (*array*) allows exporting the list of resources into a Primavera P6 file. If the resource calendars are used, you need to specify -1 for a task in the *CalendarUID* property during the export (in the **tasks** object). Then the task will use the resource calendar. |
+| **server** | (*string*) the API endpoint for the request. Can be used with the local install of the export service. The default value is `https://export.dhtmlx.com/gantt`. |
 
 Check the detailed descriptions of the export settings in the [related section](guides/export-primavera.md#export-settings).
 

--- a/docs/guides/excel.md
+++ b/docs/guides/excel.md
@@ -189,15 +189,36 @@ gantt.exportToExcel({
 
 By default, the [`exportToExcel()`](api/method/exporttoexcel.md) method exports all tasks and columns of the Gantt chart, regardless of any filtering applied via the [`onBeforeTaskDisplay`](api/event/onbeforetaskdisplay.md) event or any columns [hidden](guides/specifying-columns.md#visibility) via the `hide:true` setting.
 
-To ensure the export excludes tasks filtered out via `onBeforeTaskDisplay` and columns hidden via `hide:true`, set the **raw** property to *true*:
+To ensure the export excludes tasks filtered out via `onBeforeTaskDisplay`, set the **raw** property to *true*:
 
 ~~~js
+gantt.attachEvent("onBeforeTaskDisplay", function(id, task){
+    // hide tasks that don't match the search value
+    return task.text.toLowerCase().indexOf(filterValue.toLowerCase()) > -1;
+});
+
 gantt.exportToExcel({
     raw: true
 });
 ~~~
 
 **Related sample**: [Gantt. Export filtered data to PDF, Excel, and MSProject files](https://snippet.dhtmlx.com/twfy116w)
+
+Likewise, to exclude columns hidden via the `hide:true` setting, set the **raw** property to *true*:
+
+~~~js
+gantt.config.columns = [
+    { name: "text", tree: true, width: 150, resize: true },
+    { name: "start_date", align: "center", width: 120, resize: true },
+    // hidden columns are excluded from the export when raw: true
+    { name: "end_date", align: "center", label: "End Time", hide: true, width: 120, resize: true },
+    { name: "duration", align: "center", width: 70, hide: true, resize: true }
+];
+
+gantt.exportToExcel({
+    raw: true
+});
+~~~
 
 **Related sample**: [Gantt. Export to Excel. Hide grid columns with the raw mode](https://snippet.dhtmlx.com/b7y0ps8m)
 

--- a/docs/guides/excel.md
+++ b/docs/guides/excel.md
@@ -38,7 +38,7 @@ If several people export Gantt at the same time, the process can take more time 
 There is a common API endpoint `https://export.dhtmlx.com/gantt` which serves for all export methods (*exportToPDF*, *exportToPNG*, *exportToMSProject*, etc.). **Max request size is 10 MB**.
 
 There is also a separate API endpoint `https://export.dhtmlx.com/gantt/project` specific for the [MSProject](guides/export-msproject.md) and 
-[Primavera P6](guides/export-primavera.md)export/import services (*exportToMSProject* / *importFromMSProject* / *exportToPrimaveraP6* / *importFromPrimaveraP6* only). **Max request size: 40 MB**.
+[Primavera P6](guides/export-primavera.md) export/import services (*exportToMSProject* / *importFromMSProject* / *exportToPrimaveraP6* / *importFromPrimaveraP6* only). **Max request size: 40 MB**.
 
 ## Using export modules
 
@@ -101,6 +101,7 @@ The **exportToExcel()** method takes as a parameter an object with several prope
     - **'width'** - (*number*) the column width in pixels
     - **'type'** - (*string*) the column type
 - **server** - (*string*) sets the API endpoint for the request. Can be used with the local install of the export service. The default value is `https://export.dhtmlx.com/gantt`
+- **raw** - (*boolean*) defines the way Gantt data is exported. *false* by default. Read more in the [Exporting filtered tasks and hidden columns](#exporting-filtered-tasks-and-hidden-columns) section
 - **callback** - (*function*) If you want to receive an url to download a generated XLSX file, the callback property can be used. It receives a JSON object with the url property
 - **visual** - (*boolean*) adds the timeline chart to an exported Excel document. *false* by default
 - **cellColors** - (*boolean*) if set to *true*, the cells of the exported document will have the colors defined by the [timeline_cell_class](api/template/timeline_cell_class.md) template, the *color* and *background-color* 
@@ -183,6 +184,22 @@ gantt.exportToExcel({
 ~~~
 
 **Related sample**: [Export colors of tasks](https://snippet.dhtmlx.com/t2znjrfj)
+
+### Exporting filtered tasks and hidden columns
+
+By default, the [`exportToExcel()`](api/method/exporttoexcel.md) method exports all tasks and columns of the Gantt chart, regardless of any filtering applied via the [`onBeforeTaskDisplay`](api/event/onbeforetaskdisplay.md) event or any columns [hidden](guides/specifying-columns.md#visibility) via the `hide:true` setting.
+
+To ensure the export excludes tasks filtered out via `onBeforeTaskDisplay` and columns hidden via `hide:true`, set the **raw** property to *true*:
+
+~~~js
+gantt.exportToExcel({
+    raw: true
+});
+~~~
+
+**Related sample**: [Gantt. Export filtered data to PDF, Excel, and MSProject files](https://snippet.dhtmlx.com/twfy116w)
+
+**Related sample**: [Gantt. Export to Excel. Hide grid columns with the raw mode](https://snippet.dhtmlx.com/b7y0ps8m)
 
 ## Import from Excel {#importfromexcel}
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -247,6 +247,14 @@ table th:first-child {
 .msp-ext-properties table th:first-child {
     width: 10%;
 }
+.auto-width-table table {
+    width: auto;
+    table-layout: auto;
+}
+.auto-width-table table th:first-child,
+.auto-width-table table td:first-child {
+    width: auto;
+}
 /* end styles for tables */
 
 /* styles for infoblock */


### PR DESCRIPTION
- replace unused webixdoc_links/my_table HTML tables with GFM markdown tables on the exportToPDF, exportToPNG, exportToExcel, exportToMSProject, and exportToPrimaveraP6 method pages
- add an auto-width-table CSS class so the Excel date-format table sizes its columns to content instead of the default 25%/75% split
- document the raw parameter for exportToExcel: excludes tasks filtered via onBeforeTaskDisplay and columns hidden via hide:true
- add "Exporting filtered tasks and hidden columns" section to the Excel export guide with related samples
- fix code-fence language tags and heading spacing in exportToICal and exportToJSON pages